### PR TITLE
Allow save to parent context (which, in our case, is the main context).

### DIFF
--- a/Skopelos/src/Core/DALService.swift
+++ b/Skopelos/src/Core/DALService.swift
@@ -63,7 +63,16 @@ extension DALService: DALProtocol {
     }
     
     public func writeSync(_ changes: @escaping (NSManagedObjectContext) -> Void, completion: ((NSError?) -> Void)?) -> Self {
-        let context = slaveContext()
+        return writeSync(false, changes: changes, completion: completion)
+    }
+    
+    public func writeSync(_ saveToParentContext: Bool, changes: @escaping (NSManagedObjectContext) -> Void) -> Self {
+        return writeSync(saveToParentContext, changes: changes, completion: nil)
+    }
+    
+    public func writeSync(_ saveToParentContext: Bool, changes: @escaping (NSManagedObjectContext) -> Void, completion: ((NSError?) -> Void)?) -> Self {
+        let tempContext = slaveContext()
+        let context = saveToParentContext ? (tempContext.parent ?? tempContext) : tempContext
         context.performAndWait {
             changes(context)
             do {
@@ -82,7 +91,16 @@ extension DALService: DALProtocol {
     }
     
     public func writeAsync(_ changes: @escaping (NSManagedObjectContext) -> Void, completion: ((NSError?) -> Void)?) -> Void {
-        let context = slaveContext()
+        writeAsync(false, changes: changes, completion: completion)
+    }
+    
+    public func writeAsync(_ saveToParentContext: Bool, changes: @escaping (NSManagedObjectContext) -> Void) {
+        return writeAsync(saveToParentContext, changes: changes, completion: nil)
+    }
+    
+    public func writeAsync(_ saveToParentContext: Bool, changes: @escaping (NSManagedObjectContext) -> Void, completion: ((NSError?) -> Void)?) {
+        let tempContext = slaveContext()
+        let context = saveToParentContext ? (tempContext.parent ?? tempContext) : tempContext
         context.perform {
             changes(context)
             do {

--- a/Skopelos/src/Protocols/CommandModelProtocol.swift
+++ b/Skopelos/src/Protocols/CommandModelProtocol.swift
@@ -16,7 +16,13 @@ protocol CommandModelProtocol {
     func writeSync(_ changes: @escaping ChangesBlock) -> Self
     func writeSync(_ changes: @escaping ChangesBlock, completion: CompletionBlock?) -> Self
     
+    func writeSync(_ saveToParentContext: Bool, changes: @escaping ChangesBlock) -> Self
+    func writeSync(_ saveToParentContext: Bool, changes: @escaping ChangesBlock, completion: CompletionBlock?) -> Self
+    
     // async writings are not chainable, return value is void
     func writeAsync(_ changes: @escaping ChangesBlock) -> Void
     func writeAsync(_ changes: @escaping ChangesBlock, completion: CompletionBlock?) -> Void
+    
+    func writeAsync(_ saveToParentContext: Bool, changes: @escaping ChangesBlock) -> Void
+    func writeAsync(_ saveToParentContext: Bool, changes: @escaping ChangesBlock, completion: CompletionBlock?) -> Void
 }


### PR DESCRIPTION
This is for the instances where we want to see the changes instantly propagated to the parent (main) context.