### PR TITLE
Fix non-optional unwrapping error in Swift 3.2 / XCode 9.

### DIFF
--- a/Skopelos/src/Core/CoreDataStack.swift
+++ b/Skopelos/src/Core/CoreDataStack.swift
@@ -48,7 +48,7 @@ public final class CoreDataStack: NSObject {
     
     func initialize(_ storeType: StoreType, modelURL: URL, securityApplicationGroupIdentifier: String?, callback:((Void) -> Void)?) {
         let mom = NSManagedObjectModel(contentsOf: modelURL)
-        let coordinator = NSPersistentStoreCoordinator(managedObjectModel: mom!)
+        let coordinator = NSPersistentStoreCoordinator(managedObjectModel: mom)
         mainContext = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
         rootContext = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
         rootContext.persistentStoreCoordinator = coordinator


### PR DESCRIPTION
The NSManagedObjectModel initializer in question is no longer failable