### PR TITLE
Use a single slave context to avoid undesired concurrent updates

### DIFF
--- a/Skopelos/src/Core/DALService.swift
+++ b/Skopelos/src/Core/DALService.swift
@@ -39,12 +39,12 @@ open class DALService: NSObject {
         // override in subclasses
     }
     
-    fileprivate func slaveContext() -> NSManagedObjectContext {
+    lazy fileprivate var slaveContext: NSManagedObjectContext = {
         let slaveContext = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
         slaveContext.parent = coreDataStack.mainContext
         
         return slaveContext
-    }
+    }()
 }
 
 extension DALService: DALProtocol {
@@ -66,7 +66,7 @@ extension DALService: DALProtocol {
     
     @discardableResult
     public func writeSync(_ changes: @escaping (NSManagedObjectContext) -> Void, completion: ((NSError?) -> Void)?) -> Self {
-        let context = slaveContext()
+        let context = slaveContext
         context.performAndWait {
             changes(context)
             do {
@@ -85,7 +85,7 @@ extension DALService: DALProtocol {
     }
     
     public func writeAsync(_ changes: @escaping (NSManagedObjectContext) -> Void, completion: ((NSError?) -> Void)?) -> Void {
-        let context = slaveContext()
+        let context = slaveContext
         context.perform {
             changes(context)
             do {


### PR DESCRIPTION
Skopelos has been developed with simplicity in mind.
Concurrency is hard and allowing multiple scratch contexts to perform writing operations can cause unexpected behaviours when saving them to the main context and ultimately to the persistent store.
For instance, performing the same async operation twice could save obj1 in the slaveContext1, obj2 in the slaveContext2 ultimately causing the object (i.e. the instances obj1 and obj2) to be duplicated in the persistent store even though there should be only one.
Having a single context for the writings still allows nested writings. Nested readings were already allowed.