### PR TITLE
Add persistent store and migration (if needed) off the main thread re…

### DIFF
--- a/Skopelos/src/Core/CoreDataStack.swift
+++ b/Skopelos/src/Core/CoreDataStack.swift
@@ -51,8 +51,8 @@ public final class CoreDataStack: NSObject {
         let coordinator = NSPersistentStoreCoordinator(managedObjectModel: mom!)
         rootContext.persistentStoreCoordinator = coordinator
         mainContext.parent = rootContext
-    
-        let privateContextSetupBlock = {
+        
+        DispatchQueue.global(qos: .userInitiated).async {
             let psc = self.rootContext.persistentStoreCoordinator!
             
             switch storeType {
@@ -65,20 +65,14 @@ public final class CoreDataStack: NSObject {
                 self.addInMemoryStore(coordinator: psc)
             }
             
-            DispatchQueue.main.async {
-                callback?()
+            if let callback = callback {
+                DispatchQueue.main.async {
+                    callback()
+                }
             }
-        }
-        
-        if callback != nil {
-            DispatchQueue.global(qos: .userInitiated).async {
-                privateContextSetupBlock()
-            }
-        } else {
-            privateContextSetupBlock()
         }
     }
-
+    
     private func addSQLiteStore(coordinator: NSPersistentStoreCoordinator, dataModelFileName: String, securityApplicationGroupIdentifier: String?) {
 
         let storeURL: URL? = CoreDataStack.persistentStoreURL(dataModelFileName: dataModelFileName, securityApplicationGroupIdentifier: securityApplicationGroupIdentifier)


### PR DESCRIPTION
This PR moves the initialization off the main thread regardless of the provided callback. This should protect the caller from having the app killed by the WatchDog if the SQLite is too big to migrate in few seconds.