### PR TITLE
Improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ class SkopelosClient: Skopelos {
 
     }()
     
-    override func handle(error: Error) {
+    override func handleError(_ error: Error) {
         // clients should do the right thing here
         print(error.localizedDescription)
     }

--- a/Skopelos/SkopelosClient.swift
+++ b/Skopelos/SkopelosClient.swift
@@ -22,7 +22,7 @@ final class SkopelosClient: Skopelos {
         
     }()
     
-    override func handle(error: NSError) {
+    override func handleError(_ error: NSError) {
         // clients should do the right thing here
         print(error.localizedDescription)
     }

--- a/Skopelos/src/Core/DALService.swift
+++ b/Skopelos/src/Core/DALService.swift
@@ -82,7 +82,7 @@ extension DALService: DALProtocol {
                 try context.save()
                 self.coreDataStack.save(completion)
             } catch let error as NSError {
-                fatalError("Failed to save main context: \(error.localizedDescription), \(error.userInfo)")
+                self.handleError(error)
             }
         }
         
@@ -101,7 +101,7 @@ extension DALService: DALProtocol {
                 try context.save()
                 self.coreDataStack.save(completion)
             } catch let error as NSError {
-                fatalError("Failed to save main context: \(error.localizedDescription), \(error.userInfo)")
+                self.handleError(error)
             }
         }
     }

--- a/Skopelos/src/Core/DALService.swift
+++ b/Skopelos/src/Core/DALService.swift
@@ -34,10 +34,10 @@ open class DALService: NSObject {
     
     @objc func receiveErrorNotification(_ notification: Notification) {
         guard let userInfo = (notification as NSNotification).userInfo, let error = userInfo["error"]  else { return }
-        handle(error: error as! NSError)
+        handleError(error as! NSError)
     }
     
-    open func handle(error: NSError) {
+    open func handleError(_ error: NSError) {
         // override in subclasses
     }
     

--- a/Skopelos/src/Core/DALService.swift
+++ b/Skopelos/src/Core/DALService.swift
@@ -10,7 +10,7 @@ import Foundation
 import CoreData
 
 public struct DALServiceConstants {
-    static let handleDALServiceErrorNotification = "handleDALServiceErrorNotification"
+    static let handleErrorNotification = "handleErrorNotification"
 }
 
 open class DALService: NSObject {
@@ -19,7 +19,7 @@ open class DALService: NSObject {
     let allowsMultipleScratchContexts: Bool
     
     deinit {
-        NotificationCenter.default.removeObserver(self, name: NSNotification.Name(rawValue: DALServiceConstants.handleDALServiceErrorNotification), object: nil)
+        NotificationCenter.default.removeObserver(self, name: NSNotification.Name(rawValue: DALServiceConstants.handleErrorNotification), object: nil)
     }
     
     public init(coreDataStack cds: CoreDataStackProtocol, allowsConcurrentWritings: Bool = false) {
@@ -28,7 +28,7 @@ open class DALService: NSObject {
         super.init()
         NotificationCenter.default.addObserver(self,
                                                          selector: #selector(receiveErrorNotification),
-                                                         name: NSNotification.Name(rawValue: DALServiceConstants.handleDALServiceErrorNotification),
+                                                         name: NSNotification.Name(rawValue: DALServiceConstants.handleErrorNotification),
                                                          object: nil)
     }
     

--- a/Skopelos/src/Extensions/NSManagedObject+Skopelos.swift
+++ b/Skopelos/src/Extensions/NSManagedObject+Skopelos.swift
@@ -219,6 +219,6 @@ public extension NSManagedObjectExtendable where Self:NSManagedObject {
     }
     
     fileprivate static func handleError(_ error: Error) -> Void {
-        NotificationCenter.default.post(name: Notification.Name(rawValue: DALServiceConstants.handleDALServiceErrorNotification), object: self, userInfo: ["error": error])
+        NotificationCenter.default.post(name: Notification.Name(rawValue: DALServiceConstants.handleErrorNotification), object: self, userInfo: ["error": error])
     }
 }

--- a/Skopelos/src/Extensions/NSManagedObject+Skopelos.swift
+++ b/Skopelos/src/Extensions/NSManagedObject+Skopelos.swift
@@ -23,7 +23,7 @@ public extension NSManagedObjectExtendable where Self:NSManagedObject {
                 let inContext = try otherContext.existingObject(with: self.objectID)
                 return inContext as? Self
             } catch let error as NSError {
-                Self.handleDALServiceError(error)
+                Self.handleError(error)
             }
         }
 
@@ -43,7 +43,7 @@ public extension NSManagedObjectExtendable where Self:NSManagedObject {
         do {
             result = try context.count(for: request)
         } catch let error as NSError {
-            handleDALServiceError(error)
+            handleError(error)
             result = 0
         }
         
@@ -60,7 +60,7 @@ public extension NSManagedObjectExtendable where Self:NSManagedObject {
         do {
             result = try context.count(for: request)
         } catch let error as NSError {
-            handleDALServiceError(error)
+            handleError(error)
             result = 0
         }
 
@@ -83,7 +83,7 @@ public extension NSManagedObjectExtendable where Self:NSManagedObject {
             }
         }
         catch let error as NSError {
-            handleDALServiceError(error)
+            handleError(error)
         }
     }
     
@@ -94,7 +94,7 @@ public extension NSManagedObjectExtendable where Self:NSManagedObject {
             let results = try context.fetch(request)
             return results
         } catch let error as NSError {
-            handleDALServiceError(error)
+            handleError(error)
         }
 
         return []
@@ -108,7 +108,7 @@ public extension NSManagedObjectExtendable where Self:NSManagedObject {
             let results = try context.fetch(request)
             return results
         } catch let error as NSError {
-            handleDALServiceError(error)
+            handleError(error)
         }
 
         return []
@@ -123,7 +123,7 @@ public extension NSManagedObjectExtendable where Self:NSManagedObject {
             let results = try context.fetch(request)
             return results
         } catch let error as NSError {
-            handleDALServiceError(error)
+            handleError(error)
         }
 
         return []
@@ -138,7 +138,7 @@ public extension NSManagedObjectExtendable where Self:NSManagedObject {
             let results = try context.fetch(request)
             return results
         } catch let error as NSError {
-            handleDALServiceError(error)
+            handleError(error)
         }
 
         return []
@@ -153,7 +153,7 @@ public extension NSManagedObjectExtendable where Self:NSManagedObject {
             let results = try context.fetch(request)
             return results.first
         } catch let error as NSError {
-            handleDALServiceError(error)
+            handleError(error)
         }
 
         return nil
@@ -169,7 +169,7 @@ public extension NSManagedObjectExtendable where Self:NSManagedObject {
             let results = try context.fetch(request)
             return results.first
         } catch let error as NSError {
-            handleDALServiceError(error)
+            handleError(error)
         }
 
         return nil
@@ -186,7 +186,7 @@ public extension NSManagedObjectExtendable where Self:NSManagedObject {
             let results = try context.fetch(request)
             return results.first
         } catch let error as NSError {
-            handleDALServiceError(error)
+            handleError(error)
         }
 
         return nil
@@ -218,7 +218,7 @@ public extension NSManagedObjectExtendable where Self:NSManagedObject {
         }
     }
     
-    fileprivate static func handleDALServiceError(_ error: Error) -> Void {
+    fileprivate static func handleError(_ error: Error) -> Void {
         NotificationCenter.default.post(name: Notification.Name(rawValue: DALServiceConstants.handleDALServiceErrorNotification), object: self, userInfo: ["error": error])
     }
 }


### PR DESCRIPTION
- [x] Rename `handle(error: NSError)` to `handleError(_ error: NSError)`
- [x] Call `handleError` in case the stack fails pushing/saving the changes to the main context